### PR TITLE
2 Bugfixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,22 @@
 
           });
 
+          // Whenever we click on a live-demo (canvas or play/pause button)
+          $('body').on('click', 'div.live-demo', function (e) {
+              var $currentTarget = $(e.currentTarget),
+                  $target = $(e.target);
+              // If we clicked on the play/pause button, we still need to toggle animation
+              if (!$target.is('canvas')) {
+                $currentTarget.find('canvas').prop('physics').toggle();
+              }
+              // Toggle text
+              if ($currentTarget.hasClass('playing')) {
+                $currentTarget.removeClass('playing');
+              } else {
+                $currentTarget.addClass('playing');
+              }
+          });
+
           prettyPrint();
 
       });
@@ -231,23 +247,12 @@
   canvas.onclick = function(e) {
     physics.toggle(); // Toggle between play and paused states.
   };
+  
+  // store our physics object on the canvas so we can access it later
+  canvas.physics = physics;
 
 })();
          </script>
-         <script type="text/javascript">
-
-            // When clicking the canvas toggle pausing and playing the simulation
-            $('#particle-example').parent().click(function() {
-              var $el = $(this);
-              if ($el.hasClass('playing')) {
-                $el.removeClass('playing');
-              } else {
-                $el.addClass('playing');
-              }
-            });
-
-         </script>
-
         </div>
         <h3>Attraction</h3>
         <div class="example">
@@ -317,29 +322,22 @@
 
   };
 
+  // Bind the render function to when physics updates.
   physics.onUpdate(render);
 
+  // Render a posterframe.
   render();
 
+  // Bind canvas click to toggle.
   canvas.onclick = function(e) {
     physics.toggle(); // Toggle between play and paused states.
   };
+  
+  // store our physics object on the canvas so we can access it later
+  canvas.physics = physics;
 
 })();
           </script>
-          <script type="text/javascript">
-
-            // When clicking the canvas toggle pausing and playing the simulation
-            $('#attraction-example').parent().click(function() {
-              var $el = $(this);
-              if ($el.hasClass('playing')) {
-                $el.removeClass('playing');
-              } else {
-                $el.addClass('playing');
-              }
-            });
-
-         </script>
         </div>
 
         <h3>Spring</h3>
@@ -412,28 +410,21 @@
 
   };
 
+  // Bind the render function to when physics updates.
   physics.onUpdate(render);
 
+  // Render a posterframe.
   render();
 
+  // Bind canvas click to toggle.
   canvas.onclick = function(e) {
     physics.toggle(); // Toggle between play and paused states.
   };
+  
+  // store our physics object on the canvas so we can access it later
+  canvas.physics = physics;
 
 })();
-          </script>
-          <script type="text/javascript">
-
-            // When clicking the canvas toggle pausing and playing the simulation
-            $('#spring-example').parent().click(function() {
-              var $el = $(this);
-              if ($el.hasClass('playing')) {
-                $el.removeClass('playing');
-              } else {
-                $el.addClass('playing');
-              }
-            });
-
           </script>
         </div>
 


### PR DESCRIPTION
Fixing an error reported by Firebug as well as a bug that I experienced when checking out your documentation: I was click the play/pause button and the text was changing, but no animation was triggered.  I thought the library was broken, but then realized clicking on the canvas fixed things.

Feel free to ignore this pull request.  I'm storing the physics object on the canvas to get access to it in the "toggle text" code.  Not sure of the memory impact of this.

Tested in the latest versions of Firefox and Chrome.
